### PR TITLE
Add region awareness to keystone register.yml

### DIFF
--- a/ansible/roles/keystone/tasks/register.yml
+++ b/ansible/roles/keystone/tasks/register.yml
@@ -14,4 +14,5 @@
       name: "{{ keystone_default_user_role }}"
       auth: "{{ openstack_keystone_auth }}"
       endpoint_type: "{{ openstack_interface }}"
+      region_name: "{{ openstack_region_name }}"
   run_once: True


### PR DESCRIPTION
This shouldn't be necessary if the two regions are properly synchronized, I think.