### PR TITLE
[neutron_server] overwrite default server timeout

### DIFF
--- a/ansible/roles/haproxy/defaults/main.yml
+++ b/ansible/roles/haproxy/defaults/main.yml
@@ -66,3 +66,6 @@ haproxy_process_cpu_map: "no"
 
 haproxy_dimensions: "{{ default_container_dimensions }}"
 keepalived_dimensions: "{{ default_container_dimensions }}"
+
+# extra options
+haproxy_listen_neutron_server_extra: []

--- a/ansible/roles/haproxy/templates/haproxy.cfg.j2
+++ b/ansible/roles/haproxy/templates/haproxy.cfg.j2
@@ -364,6 +364,9 @@ listen nova_serialconsole_proxy_external
 listen neutron_server
   option http-tunnel
   bind {{ kolla_internal_vip_address }}:{{ neutron_server_port }}
+{% for extra_option in haproxy_listen_neutron_server_extra %}
+  {{ extra_option }}
+{% endfor %}
 {% for http_option in haproxy_listen_http_extra %}
   {{ http_option }}
 {% endfor %}


### PR DESCRIPTION
ref: https://www.ajg.id.au/2019/01/29/connectionerror-connection-aborted-badstatusline-openstack/