### PR TITLE
[common] reload connections for fluentd/ES

### DIFF
--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -15,6 +15,7 @@
        logstash_format true
        logstash_prefix {{ kibana_log_prefix }}
        flush_interval 15s
+       reconnect_on_error true
   </store>
 {% elif enable_monasca | bool %}
     type copy
@@ -51,6 +52,7 @@
        logstash_format true
        logstash_prefix {{ kibana_log_prefix }}
        flush_interval 15s
+       reconnect_on_error true
   </store>
 {% elif enable_monasca | bool %}
     type copy


### PR DESCRIPTION
This should keep fluentd from being unable to connect to elasticsearch.