### PR TITLE
Add support for OpenID Connect Keystone federation

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -545,6 +545,7 @@ enable_glance: "{{ enable_openstack_core | bool }}"
 enable_haproxy: "yes"
 enable_keepalived: "{{ enable_haproxy | bool }}"
 enable_keystone: "{{ enable_openstack_core | bool }}"
+enable_keystone_federation: "{{ (keystone_identity_providers | length > 0) and (keystone_identity_mappings | length > 0) }}"
 enable_mariadb: "yes"
 enable_memcached: "yes"
 enable_neutron: "{{ enable_openstack_core | bool }}"
@@ -1167,6 +1168,7 @@ telegraf_enable_docker_input: "no"
 # * client_id (client id used by the OpenId Connect Protocol);
 # * client_secret (client secret used by the OpenId Connect protocol);
 # * attribute_mapping (the attribute mapping to be used for this IdP. This mapping is expected to already exist in OpenStack.);
+# * metadata_url
 # * certificate_url (a URL file://, http:// or https:// to the certificate pem of the IdP);
 # * key_id (the id of the issuer's public key, you can also retrieve it from the /certs IdP url, this value also accept a url);
 # * certificate_transformer (In some cases, if the "certificate_url" does not return a certificate, but an XML or another format
@@ -1175,14 +1177,16 @@ telegraf_enable_docker_input: "no"
 # * key_transformer (same as the certificate_transformer, but receives a 'key_id' variable)
 #
 # The IdPs meta information are to be presented to Kolla-ansible as the following example:
-# identity_providers:
+# keystone_identity_providers:
 #   - {name: "myidp1", protocol: "openid", identifier: "https://accounts.google.com", public_name: "Authenticate via myidp1", client_id: "myidp1.client.id", client_secret: "myidp1-secret", attribute_mapping: "mappingId1", organization_domain_name: "xyz.com", certificate_url: "url/to/the/idp/certificate", key_id: "the-idp-public-key-id-or-a-url-to-load-the-key-id", certificate_transformer: "python-command-to-do-some-transformation-in-the-certificate", key_transformer: "python-command-to-do-some-transformation-in-the-key-id"}
 #
 # We also need to configure the attribute mapping that is used by IdPs. The configuration of attribute mappings is a list of objects, where each object must have a 'name' (that mapps to the 'attribute_mapping' to the IdP object in the IdPs set), and the 'file' with a full qualified path to a mapping file.
-# identity_providers_attribute_mappings:
+# keystone_identity_mappings:
 #   - {name: "mappingId1", file: "/full/qualified/path/to/mapping/json/file/to/mappingId1"}
 #   - {name: "mappingId2", file: "/full/qualified/path/to/mapping/json/file/to/mappingId2"}
 #   - {name: "mappingId3", file: "/full/qualified/path/to/mapping/json/file/to/mappingId3"}
+keystone_identity_providers: []
+keystone_identity_mappings: []
 
 # The identity API version to be used to register IdPs in OpenStack
 identity_api_version: 3

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -225,7 +225,7 @@ OPENSTACK_KEYSTONE_DEFAULT_ROLE = "{{ keystone_default_user_role }}"
 # and federation protocol combination (WEBSSO_IDP_MAPPING).
 {% if enable_keystone_federation | bool %}
 WEBSSO_ENABLED = True
-WEBSSO_KEYSTONE_URL = "{{ keystone_public_url }}"
+WEBSSO_KEYSTONE_URL = "{{ keystone_public_url }}/v3"
 WEBSSO_CHOICES = (
     ("credentials", _("Keystone Credentials")),
     {% for idp in keystone_identity_providers %}

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -223,12 +223,12 @@ OPENSTACK_KEYSTONE_DEFAULT_ROLE = "{{ keystone_default_user_role }}"
 # Do not remove the mandatory credentials mechanism.
 # Note: The last two tuples are sample mapping keys to a identity provider
 # and federation protocol combination (WEBSSO_IDP_MAPPING).
-{% if keystone_identity_providers is defined and keystone_identity_providers | length > 0 %}
+{% if enable_keystone_federation | bool %}
 WEBSSO_ENABLED = True
 WEBSSO_CHOICES = (
     ("credentials", _("Keystone Credentials")),
     {% for idp in keystone_identity_providers %}
-    ("{{idp.name}}", "{{idp.public_name}}"),
+    ("{{ idp.name }}", "{{ idp.public_name }}"),
     {% endfor %}
 )
 
@@ -241,7 +241,7 @@ WEBSSO_CHOICES = (
 # NOTE: The value is expected to be a tuple formatted as: (<idp_id>, <protocol_id>).
 WEBSSO_IDP_MAPPING = {
 {% for idp in keystone_identity_providers %}
-    "{{idp.name}}": ("{{idp.name}}", "{{idp.protocol}}"),
+    "{{ idp.name }}": ("{{ idp.name }}", "{{ idp.protocol }}"),
 {% endfor %}
 }
 {% endif %}

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -223,11 +223,11 @@ OPENSTACK_KEYSTONE_DEFAULT_ROLE = "{{ keystone_default_user_role }}"
 # Do not remove the mandatory credentials mechanism.
 # Note: The last two tuples are sample mapping keys to a identity provider
 # and federation protocol combination (WEBSSO_IDP_MAPPING).
-{% if identity_providers is defined and identity_providers | length > 0 %}
+{% if keystone_identity_providers is defined and keystone_identity_providers | length > 0 %}
 WEBSSO_ENABLED = True
 WEBSSO_CHOICES = (
     ("credentials", _("Keystone Credentials")),
-    {% for idp in identity_providers %}
+    {% for idp in keystone_identity_providers %}
     ("{{idp.name}}", "{{idp.public_name}}"),
     {% endfor %}
 )
@@ -240,7 +240,7 @@ WEBSSO_CHOICES = (
 # as the protocol_id when redirecting to the WebSSO by protocol endpoint.
 # NOTE: The value is expected to be a tuple formatted as: (<idp_id>, <protocol_id>).
 WEBSSO_IDP_MAPPING = {
-{% for idp in identity_providers %}
+{% for idp in keystone_identity_providers %}
     "{{idp.name}}": ("{{idp.name}}", "{{idp.protocol}}"),
 {% endfor %}
 }

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -225,6 +225,7 @@ OPENSTACK_KEYSTONE_DEFAULT_ROLE = "{{ keystone_default_user_role }}"
 # and federation protocol combination (WEBSSO_IDP_MAPPING).
 {% if enable_keystone_federation | bool %}
 WEBSSO_ENABLED = True
+WEBSSO_KEYSTONE_URL = "{{ keystone_public_url }}"
 WEBSSO_CHOICES = (
     ("credentials", _("Keystone Credentials")),
     {% for idp in keystone_identity_providers %}

--- a/ansible/roles/keystone/defaults/main.yml
+++ b/ansible/roles/keystone/defaults/main.yml
@@ -163,6 +163,7 @@ remote_id_attribute_saml: "Shib-Identity-Provider"
 remote_id_attribute_oidc: "HTTP_OIDC_ISS"
 keystone_federation_oidc_metadata: "{{ '/etc/apache2/metadata' if kolla_base_distro in ['debian', 'ubuntu'] else '/etc/httpd/metadata' }}"
 keystone_federation_oidc_certificate: "{{ '/etc/apache2/cert' if kolla_base_distro in ['debian', 'ubuntu'] else '/etc/httpd/cert' }}"
+keystone_federation_openid_discovery_url:
 
 # This variables is used to define multiple trusted Horizon dashboards.
 # horizon_trusted_dashboards: ['<https://dashboardServerOne/auth/websso/>', '<https://dashboardServerTwo/auth/websso/>', '<https://dashboardServerN/auth/websso/>']

--- a/ansible/roles/keystone/defaults/main.yml
+++ b/ansible/roles/keystone/defaults/main.yml
@@ -161,11 +161,8 @@ keystone_wsgi_admin_vhost_config: |
 remote_id_attribute_saml: "Shib-Identity-Provider"
 # Default OpenID Connect remote attribute key
 remote_id_attribute_oidc: "HTTP_OIDC_ISS"
-oidc_crypto_passphrase: "OIDC_cryptographic_passphrase_that_you_must_change_in_production"
-container_keystone_federation_oidc_metadata_folder: "{{ '/etc/apache2/metadata' if kolla_base_distro in ['debian', 'ubuntu'] else '/etc/httpd/metadata' }}"
-container_keystone_federation_oidc_idp_certificate_folder: "{{ '/etc/apache2/cert' if kolla_base_distro in ['debian', 'ubuntu'] else '/etc/httpd/cert' }}"
-host_keystone_federation_oidc_metadata_folder: "{{ node_config_directory }}/keystone/metadata"
-host_keystone_federation_oidc_idp_certificate_folder: "{{ node_config_directory }}/keystone/cert"
+keystone_federation_oidc_metadata: "{{ '/etc/apache2/metadata' if kolla_base_distro in ['debian', 'ubuntu'] else '/etc/httpd/metadata' }}"
+keystone_federation_oidc_certificate: "{{ '/etc/apache2/cert' if kolla_base_distro in ['debian', 'ubuntu'] else '/etc/httpd/cert' }}"
 
 # This variables is used to define multiple trusted Horizon dashboards.
 # horizon_trusted_dashboards: ['<https://dashboardServerOne/auth/websso/>', '<https://dashboardServerTwo/auth/websso/>', '<https://dashboardServerN/auth/websso/>']

--- a/ansible/roles/keystone/defaults/main.yml
+++ b/ansible/roles/keystone/defaults/main.yml
@@ -167,3 +167,6 @@ keystone_federation_oidc_certificate: "{{ '/etc/apache2/cert' if kolla_base_dist
 # This variables is used to define multiple trusted Horizon dashboards.
 # horizon_trusted_dashboards: ['<https://dashboardServerOne/auth/websso/>', '<https://dashboardServerTwo/auth/websso/>', '<https://dashboardServerN/auth/websso/>']
 horizon_trusted_dashboards: ["{{ public_protocol }}://{{kolla_external_fqdn}}/auth/websso/"]
+
+enable_keystone_federation_openid: "{{ keystone_identity_providers | default([]) | selectattr('protocol','equalto','openid') | list | count > 0 }}"
+enable_keystone_federation_saml: "{{ keystone_identity_providers | default([]) | selectattr('protocol','equalto','saml') | list | count > 0 }}"

--- a/ansible/roles/keystone/files/openid_gen_metadata_and_certs.py
+++ b/ansible/roles/keystone/files/openid_gen_metadata_and_certs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,7 +14,9 @@
 # This module creates a list of cron intervals for a node in a group of nodes
 # to ensure each node runs a cron in round robbin style.
 
+import argparse
 import json
+import os
 import re
 import requests
 import sys
@@ -25,60 +28,92 @@ else:
 
 
 def main(argv):
-    posargs = iter(argv)
+    parser = argparse.ArgumentParser(description=(
+        'Generate mod_oidc metadata files for a given identity provider. See '
+        'https://github.com/zmartzone/mod_auth_openidc/wiki/Multiple-Providers '
+        'for examples of the files this generates.'))
 
-    idp_url = next(posargs)
-    client_id = next(posargs)
-    client_secret = next(posargs)
-    certificate = next(posargs, None)
-    key_id = next(posargs, None)
-    certificate_transformer = next(posargs, None)
-    key_transformer = next(posargs, None)
+    parser.add_argument('--output-dir', required=True,
+                        help=('The directory to output the metadata/cert files '
+                              'into.'))
+    parser.add_argument('--identity-provider-url', required=True,
+                        help=('The fully qualified hostname of the remote '
+                              'identity provider.'))
+    parser.add_argument('--client-id', required=True,
+                        help='the OpenID client public ID')
+    parser.add_argument('--client-secret', required=True,
+                        help='the OpenID client secret')
+    parser.add_argument('--jwt-certificate-path',
+                        help=('The fully qualified names of the files that '
+                              'contain the X.509 certificates with the RSA '
+                              'public keys that can be used for local JWT '
+                              'access token verification.'))
+    parser.add_argument('--jwt-certificate-transformer', help='')
+    parser.add_argument('--jwt-key-path', help='')
+    parser.add_argument('--jwt-key-transformer', help='')
 
+    args = parser.parse_args(argv)
+
+    output_dir = args.output_dir
+    idp_url = args.identity_provider_url
+    client_id = args.client_id
+    client_secret = args.client_secret
+    jwt_certificate_path = args.jwt_certificate_path
+    jwt_certificate_transformer = args.jwt_certificate_transformer
+    jwt_key_path = args.jwt_key_path
+    jwt_key_transformer = args.jwt_key_transformer
+
+    metadata_dir = os.path.join(output_dir, "metadata")
+    certificate_dir = os.path.join(output_dir, "cert")
     file_name = quote_plus(re.sub("https?://", "", idp_url))
     json_provider_url = idp_url + '/.well-known/openid-configuration'
 
-    json_provider = json.dumps(requests.get(json_provider_url).json())
+    json_provider = requests.get(json_provider_url).json()
+    jwks_uri = json_provider.get("jwks_uri")
+
     # This variable is an empty json because we are not overriding any configuration
     # and the apache2 OIDC plugin needs an existing config file with a valid json,
     # even if this JSON is an empty one.
     json_conf = {}
-    json_client = json.dumps({'client_id': client_id, 'client_secret': client_secret})
+    json_client = {'client_id': client_id, 'client_secret': client_secret}
 
-    if key_id and certificate:
-        key_id = get_value_by_url(key_id)
-        if key_transformer:
-            key_id = eval(key_transformer)
-        certificate = get_value_by_url(certificate)
-        if certificate_transformer:
-            certificate = eval(certificate_transformer)
-    elif not (key_id or certificate):
-        jwks_uri = json_provider.get("jwks_uri")
-        if jwks_uri:
-            key_id, certificate = fetch_jkws_key(jwks_uri)
-    else
-        raise ValueError(
-            "Either both a key_id and a certificate must be specified, or else "
-            "neither, in which case the values are automatically inferred from "
-            "the IdP well-known metadata URL.")
+    if not jwt_key_path:
+        jwt_key_path = jwks_uri
+    if not jwt_certificate_path:
+        jwt_certificate_path = jwks_uri
 
-    create_file("metadata", file_name, "provider", json_provider)
-    create_file("metadata", file_name, "client", json_client)
-    create_file("metadata", file_name, "conf", json_conf)
+    jwt_key = get_value_by_url(jwt_key_path)
+    jwt_certificate = get_value_by_url(jwt_certificate_path)
 
-    if key_id and certificate:
-        create_file("cert", key_id, "pem", certificate)
-        print(key_id)
+    if jwt_certificate_transformer:
+        jwt_certificate = eval(jwt_certificate_transformer)
+    else:
+        jwt_certificate = default_jwt_certificate_transformer(jwt_certificate)
+
+    if jwt_key_transformer:
+        jwt_key = eval(jwt_key_transformer)
+    else:
+        jwt_key = default_jwt_key_transformer(jwt_key)
+
+    create_file(metadata_dir, file_name, "provider", json.dumps(json_provider))
+    create_file(metadata_dir, file_name, "client", json.dumps(json_client))
+    create_file(metadata_dir, file_name, "conf", json.dumps(json_conf))
+
+    if jwt_key and jwt_certificate:
+        create_file(certificate_dir, jwt_key, "pem", jwt_certificate)
+        print(jwt_key)
 
 
-def fetch_jkws_key(jwks_uri):
-    certs = json.dumps(requests.get(jwks_uri))
-    keys = certs.get("keys")
+def default_jwt_key_transformer(jwt_key):
+    keys = json.loads(jwt_key).get("keys")
 
-    if not keys:
-        return None, None
+    return keys[0]["kid"] if keys else None
 
-    return keys[0]["kid"], keys[0]["x5c"][0]
+
+def default_jwt_certificate_transformer(jwt_certificate):
+    keys = json.loads(jwt_certificate).get("keys")
+
+    return keys[0]["x5c"][0] if keys else None
 
 
 def create_file(file_path, file_name, extension, content):

--- a/ansible/roles/keystone/tasks/config.yml
+++ b/ansible/roles/keystone/tasks/config.yml
@@ -1,32 +1,4 @@
 ---
-- name: Check if OpenID Connect and SAML are enabled for OpenStack federation
-  set_fact:
-    keystone_federated_protocol_openid_enabled: "{{(keystone_federated_protocol_openid_enabled is defined and keystone_federated_protocol_openid_enabled) or item.protocol == 'openid'}}"
-    keystone_federated_protocol_saml_enabled: "{{(keystone_federated_protocol_saml_enabled is defined and keystone_federated_protocol_saml_enabled) or item.protocol == 'saml'}}"
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0)
-  with_items: "{{identity_providers}}"
-
-- name: Check if the OpenID Connect protocol should be used
-  set_fact:
-    should_use_oidc: "{{ keystone_federated_protocol_openid_enabled is defined and keystone_federated_protocol_openid_enabled }}"
-
-- name: Check if the SAML protocol should be used
-  set_fact:
-    should_use_saml: "{{ keystone_federated_protocol_saml_enabled is defined and keystone_federated_protocol_saml_enabled }}"
-
-# NOTE(pem): Variable used to control the cleanup of attribute mappings that
-# are in OpenStack, but not in Kolla-Ansible configuration files.
-# For security reasons the default is set to False
-- set_fact: should_remove_attribute_mappings=False
-  when: should_remove_attribute_mappings is not defined
-
-
-# NOTE(pem): Variable used to control the cleanup of identity providers that
-# are integrated with OpenStack, but not in Kolla-Ansible configuration files.
-# For security reasons the default is set to False
-- set_fact: should_remove_identity_providers=False
-  when: should_remove_identity_providers is not defined
-
 - name: Ensuring config directories exist
   file:
     path: "{{ node_config_directory }}/{{ item.key }}"
@@ -75,49 +47,51 @@
   notify:
     - Restart {{ item.key }} container
 
-- name: Copying 'create_oidc_idp_metadata_and_certificate_files.py' to the Apache HTTPD folder
-  template:
-    src: create_oidc_idp_metadata_and_certificate_files.py.j2
-    dest: "{{ node_config_directory }}keystone/create_oidc_idp_metadata_and_certificate_files.py"
-    mode: 0755
-  when: identity_providers is defined and keystone_federated_protocol_openid_enabled
+- name: Check if OpenID Connect and SAML are enabled for OpenStack federation
+  set_fact:
+    enable_keystone_federation_openid: <
+      {{ keystone_identity_providers | default([])
+         | selectattr('protocol','equalto','openid') | list | count > 0 }}
+    enable_keystone_federation_saml: <
+      {{ keystone_identity_providers | default([])
+         | selectattr('protocol','equalto','saml') | list | count > 0 }}
 
-- name: Remove all metadata and certificate files. They will be added/updated again in the next task. This ensures that the metadata from removed IdPs are cleaned up
+- name: Remove all metadata and certificate files
   file:
     state: absent
-    path: "{{ item }}/"
-  when: item is defined and item | trim | length > 0
+    path: "{{ item }}"
   with_items:
-    - "{{ host_keystone_federation_oidc_metadata_folder }}"
-    - "{{ host_keystone_federation_oidc_idp_certificate_folder }}"
+    - metadata
+    - cert
 
-- name: Creating Identity providers certificates directory
+- name: Create OpenID configuration directories
   file:
-    dest: "{{ host_keystone_federation_oidc_idp_certificate_folder }}"
+    dest: "{{ item }}"
     state: "directory"
     mode: "0770"
   become: true
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0) and item.protocol == 'openid'
+  with_items:
+    - metadata
+    - cert
+  when: enable_keystone_federation_openid
 
-- name: Creating Identity providers metadata directory
-  file:
-    dest: "{{ host_keystone_federation_oidc_metadata_folder }}"
-    state: "directory"
-    mode: "0770"
-  become: true
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0) and item.protocol == 'openid'
-
-- name: Configure the metadata files for OpenID Connect IdPs
-  shell: >
-    python "{{ node_config_directory }}keystone/create_oidc_idp_metadata_and_certificate_files.py" "{{item.identifier}}" "{{item.client_id}}" "{{item.client_secret}}" "{{item.certificate_url}}" "{{item.key_id}}" "{{item.certificate_transformer}}" "{{item.key_transformer}}"
+- name: Configure the metadata files for OpenID IdPs
+  script: >
+    openid_gen_metadata_and_certs.py \
+    "{{ item.identifier }}" "{{ item.client_id }}" "{{ item.client_secret }}" \
+    "{{ item.certificate_url }}" "{{ item.key_id }}" \
+    "{{ item.certificate_transformer }}" "{{ item.key_transformer }}"
   register: certificate_key_ids
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0) and item.protocol == 'openid'
-  with_items: "{{identity_providers}}"
+  when:
+    - item.protocol == 'openid'
+  with_items: "{{ keystone_identity_providers | default([]) }}"
 
 - name: Setting the certificates variable
   set_fact:
-    certificate_key_ids: "{{ certificate_key_ids.results | map(attribute='stdout') | map('regex_replace', '(.*)', '\\1#' + container_keystone_federation_oidc_idp_certificate_folder + '/\\1.pem') | join(' ') }}"
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0) and item.protocol == 'openid'
+    certificate_key_ids: <
+      {{ certificate_key_ids.results | map(attribute='stdout') | map('trim') | reject
+         | map('regex_replace', '(.*)', '\\1#' + keystone_federation_oidc_certificate + '/\\1.pem')
+         | list }}
 
 - name: Copying over keystone.conf
   vars:

--- a/ansible/roles/keystone/tasks/config.yml
+++ b/ansible/roles/keystone/tasks/config.yml
@@ -47,51 +47,60 @@
   notify:
     - Restart {{ item.key }} container
 
-- name: Check if OpenID Connect and SAML are enabled for OpenStack federation
-  set_fact:
-    enable_keystone_federation_openid: <
-      {{ keystone_identity_providers | default([])
-         | selectattr('protocol','equalto','openid') | list | count > 0 }}
-    enable_keystone_federation_saml: <
-      {{ keystone_identity_providers | default([])
-         | selectattr('protocol','equalto','saml') | list | count > 0 }}
-
-- name: Remove all metadata and certificate files
+- name: Remove all OpenID metadata and certificate files
+  vars:
+    keystone: "{{ keystone_services.keystone }}"
   file:
     state: absent
-    path: "{{ item }}"
+    path: "{{ node_config_directory }}/keystone/{{ item }}"
   with_items:
     - metadata
     - cert
+  when:
+    - inventory_hostname in groups[keystone.group]
+    - keystone.enabled | bool
 
 - name: Create OpenID configuration directories
+  vars:
+    keystone: "{{ keystone_services.keystone }}"
   file:
-    dest: "{{ item }}"
+    dest: "{{ node_config_directory }}/keystone/{{ item }}"
     state: "directory"
     mode: "0770"
   become: true
   with_items:
     - metadata
     - cert
-  when: enable_keystone_federation_openid
+  when:
+    - enable_keystone_federation_openid | bool
+    - inventory_hostname in groups[keystone.group]
+    - keystone.enabled | bool
 
 - name: Configure the metadata files for OpenID IdPs
+  vars:
+      keystone: "{{ keystone_services.keystone }}"
   script: >
     openid_gen_metadata_and_certs.py \
-    "{{ item.identifier }}" "{{ item.client_id }}" "{{ item.client_secret }}" \
-    "{{ item.certificate_url }}" "{{ item.key_id }}" \
-    "{{ item.certificate_transformer }}" "{{ item.key_transformer }}"
+    --output-dir={{ node_config_directory }}/keystone \
+    --identity-provider-url={{ item.identifier }} \
+    --client-id="{{ item.client_id }}" \
+    --client-secret="{{ item.client_secret }}" \
+    --jwt-certificate-path="{{ item.certificate_url|default("") }}" \
+    --jwt-certificate-transformer="{{ item.certificate_transformer|default("") }}" \
+    --jwt-key-path="{{ item.key_id|default("") }}" \
+    --jwt-key-transformer="{{ item.key_transformer|default("") }}"
   register: certificate_key_ids
   when:
     - item.protocol == 'openid'
+    - inventory_hostname in groups[keystone.group]
+    - keystone.enabled | bool
   with_items: "{{ keystone_identity_providers | default([]) }}"
+  loop_control:
+    label: "{{ item.client_id }} ({{ item.protocol }})"
 
 - name: Setting the certificates variable
   set_fact:
-    certificate_key_ids: <
-      {{ certificate_key_ids.results | map(attribute='stdout') | map('trim') | reject
-         | map('regex_replace', '(.*)', '\\1#' + keystone_federation_oidc_certificate + '/\\1.pem')
-         | list }}
+    certificate_key_ids: "{{ certificate_key_ids.results | map(attribute='stdout') | map('trim') | reject | map('regex_replace', '(.*)', '\\1#' + keystone_federation_oidc_certificate + '/\\1.pem') | list }}"
 
 - name: Copying over keystone.conf
   vars:

--- a/ansible/roles/keystone/tasks/deploy.yml
+++ b/ansible/roles/keystone/tasks/deploy.yml
@@ -20,7 +20,4 @@
 
 - include_tasks: register_identity_providers.yml
   when:
-    - keystone_identity_providers is defined
-    - keystone_identity_providers is not none
-    - identity_provider_attribute_mappings is defined
-    - identity_provider_attribute_mappings is not none
+    - enable_keystone_federation | bool

--- a/ansible/roles/keystone/tasks/deploy.yml
+++ b/ansible/roles/keystone/tasks/deploy.yml
@@ -19,4 +19,8 @@
 - include_tasks: check.yml
 
 - include_tasks: register_identity_providers.yml
-  when: identity_providers is defined
+  when:
+    - keystone_identity_providers is defined
+    - keystone_identity_providers is not none
+    - identity_provider_attribute_mappings is defined
+    - identity_provider_attribute_mappings is not none

--- a/ansible/roles/keystone/tasks/init_fernet.yml
+++ b/ansible/roles/keystone/tasks/init_fernet.yml
@@ -20,6 +20,7 @@
   loop: "{{ keystone_fernet_token_list }}"
   loop_control:
     index_var: index
+  no_log: true
 
 - name: Waiting for Keystone SSH port to be UP
   wait_for:

--- a/ansible/roles/keystone/tasks/register_identity_providers.yml
+++ b/ansible/roles/keystone/tasks/register_identity_providers.yml
@@ -44,7 +44,7 @@
   run_once: True
   when:
     - item.name not in existing_mappings
-  with_items: "{{ keystone_keystone_identity_mappings }}"
+  with_items: "{{ keystone_identity_mappings }}"
   delegate_to: localhost
 
 - name: Update existing attribute mappings in OpenStack
@@ -60,7 +60,7 @@
   run_once: True
   when:
     - item.name in existing_mappings
-  with_items: "{{ keystone_keystone_identity_mappings }}"
+  with_items: "{{ keystone_identity_mappings }}"
   delegate_to: localhost
 
 - name: List configured IdPs

--- a/ansible/roles/keystone/tasks/register_identity_providers.yml
+++ b/ansible/roles/keystone/tasks/register_identity_providers.yml
@@ -1,69 +1,70 @@
 ---
-- set_fact: identity_providers_attribute_mappings_names="{{ (identity_providers_attribute_mappings | map(attribute='name') | join(',') )  }}"
-  when: identity_providers_attribute_mappings is defined
-
 - name: List configured attribute mappings (that can be used by IdPs)
-  shell: >
+  command: >
     docker exec -t keystone openstack \
-    --os-auth-url={{ openstack_auth.auth_url }} \
-    --os-password={{ openstack_auth.password }} \
-    --os-username={{ openstack_auth.username }} \
-    --os-project-name={{ openstack_auth.project_name }} \
-    --os-identity-api-version={{ identity_api_version }} \
+      --os-auth-url={{ openstack_auth.auth_url }} \
+      --os-password={{ openstack_auth.password }} \
+      --os-username={{ openstack_auth.username }} \
+      --os-project-name={{ openstack_auth.project_name }} \
+      --os-identity-api-version={{ identity_api_version }} \
     mapping list -c ID --format value
   run_once: True
-  become: true
-  register: configured_attribute_mappings_register
-  when: identity_providers_attribute_mappings is defined
+  become: True
+  register: existing_mappings_register
 
-- set_fact: configured_attribute_mappings="{{ configured_attribute_mappings_register.stdout.split('\n') | map('trim') | list  | join(',') }}"
-  when: configured_attribute_mappings_register is defined and configured_attribute_mappings_register.stdout is defined
+- set_fact:
+    existing_mappings: "{{ existing_mappings_register.stdout.split('\n') | map('trim') | list }}"
 
-- set_fact: identity_providers_attribute_mappings_names="{{ (identity_providers_attribute_mappings | map(attribute='name') | join(',') )  }}"
-  when: identity_providers_attribute_mappings is defined
-
-- name: Remove attribute mappings that are defined in OpenStack, but not in Kolla-Ansible configuration files
-  shell: >
+- name: Remove unmanaged attribute mappings
+  command: >
     docker exec -t keystone openstack \
     --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    mapping delete {{item | trim }}
+    mapping delete {{ item }}
   run_once: True
   become: true
-  with_items: "{{configured_attribute_mappings.split(',')}}"
-  when: identity_providers_attribute_mappings is defined and should_remove_attribute_mappings and item not in identity_providers_attribute_mappings_names.split(',')
+  with_items: "{{ existing_mappings }}"
+  when:
+    - item not in (keystone_identity_mappings | map(attribute='name') | list)
+    - should_remove_attribute_mappings | default(False)
 
 - name: Register attribute mappings in OpenStack
-  shell: >
+  command: >
     openstack --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    mapping create --rules "{{item.file}}" "{{item.name}}"
+    mapping create \
+    --rules "{{ item.file }}" \
+    {{ item.name }}
   run_once: True
-  when: identity_providers_attribute_mappings is defined and (identity_providers_attribute_mappings is not none) and (identity_providers_attribute_mappings | length > 0) and item.name not in configured_attribute_mappings.split(',')
-  with_items: "{{identity_providers_attribute_mappings}}"
+  when:
+    - item.name not in existing_mappings
+  with_items: "{{ keystone_keystone_identity_mappings }}"
   delegate_to: localhost
 
-- name: Update attribute mappings in OpenStack
-  shell: >
+- name: Update existing attribute mappings in OpenStack
+  command: >
     openstack --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    mapping set --rules "{{item.file}}" "{{item.name}}"
+    mapping set \
+    --rules "{{ item.file }}" \
+    {{ item.name }}
   run_once: True
-  when: identity_providers_attribute_mappings is defined and identity_providers_attribute_mappings is not none and (identity_providers_attribute_mappings | length > 0) and item.name in configured_attribute_mappings.split(',')
-  with_items: "{{identity_providers_attribute_mappings}}"
+  when:
+    - item.name in existing_mappings
+  with_items: "{{ keystone_keystone_identity_mappings }}"
   delegate_to: localhost
 
 - name: List configured IdPs
-  shell: >
+  command: >
     docker exec -t keystone openstack \
     --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
@@ -73,86 +74,98 @@
     identity provider list -c ID --format value
   run_once: True
   become: true
-  register: configured_identity_providers_register
-  when: identity_providers is defined
+  register: existing_idps_register
 
-- set_fact: configured_identity_providers="{{ configured_identity_providers_register.stdout.split('\n') | map('trim') | list  | join(',')}}"
-  when: configured_identity_providers_register is defined and configured_identity_providers_register.stdout is defined
+- set_fact:
+    existing_idps: "{{ existing_idps_register.stdout.split('\n') | map('trim') | list }}"
 
-- set_fact: identity_providers_names="{{ (identity_providers | map(attribute='name') | join(',') )  }}"
-  when: identity_providers is defined
-
-- name: Remove identity providers that are defined in OpenStack, but not in Kolla-Ansible configuration files
-  shell: >
+- name: Remove unmanaged identity providers
+  command: >
     docker exec -t keystone openstack \
     --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    identity provider delete {{item | trim }}
+    identity provider delete {{ item }}
   run_once: True
   become: true
-  with_items: "{{configured_identity_providers.split(',')}}"
-  when: identity_providers is defined and should_remove_identity_providers and (item | trim) not in identity_providers_names.split(',')
+  with_items: "{{ existing_idps }}"
+  when:
+    - item not in (keystone_identity_providers | map(attribute='name') | list)
+    - should_remove_identity_providers | default(False)
 
 - name: Register Identity Providers in OpenStack
-  shell: >
+  command: >
     docker exec -t keystone openstack \
     --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    identity provider create --description "{{item.public_name}}" --remote-id "{{item.identifier}}" "{{item.name}}"
+    identity provider create \
+    --description "{{ item.public_name }}" \
+    --remote-id "{{ item.identifier }}" \
+    {{ item.name }}
   run_once: True
   become: true
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0) and item.name not in configured_identity_providers.split(',')
-  with_items: "{{identity_providers}}"
+  when:
+    - item.name not in existing_idps
+  with_items: "{{ keystone_identity_providers }}"
 
 - name: Update Identity Providers in OpenStack according to Kolla-Ansible configuraitons
-  shell: >
+  command: >
     docker exec -t keystone openstack \
     --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    identity provider set --description "{{item.public_name}}" --remote-id "{{item.identifier}}" "{{item.name}}"
+    identity provider set \
+    --description "{{ item.public_name }}" \
+    --remote-id "{{ item.identifier }}" \
+    "{{ item.name }}"
   run_once: True
   become: true
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0) and item.name in configured_identity_providers.split(',')
-  with_items: "{{identity_providers}}"
+  when:
+    - item.name in existing_idps
+  with_items: "{{ keystone_identity_providers }}"
 
 - name: Configure attribute mappings for each Identity Provider. (We expect the mappings to be configured by the operator)
-  shell: >
+  command: >
     docker exec -t keystone openstack \
     --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    federation protocol create {{item.protocol}} --mapping {{item.attribute_mapping}} --identity-provider {{item.name}}
+    federation protocol create \
+    --mapping {{ item.attribute_mapping }} \
+    --identity-provider {{ item.name }} \
+    {{ item.protocol }}
   run_once: True
   become: true
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0) and item.name not in configured_identity_providers.split(',')
-  with_items: "{{identity_providers}}"
-
-
-# NOTE(pem): We must allow this task to "fail" because the OpenStack CLI is
-# returning RC=1 for sucessful executions.
+  when:
+    - item.name not in existing_idps
+  with_items: "{{ keystone_identity_providers }}"
 
 - name: Update attribute mappings for each Identity Provider. (We expect the mappings to be configured by the operator).
-  shell: >
+  command: >
     docker exec -t keystone openstack \
     --os-auth-url={{ openstack_auth.auth_url }} \
     --os-password={{ openstack_auth.password }} \
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
-    federation protocol set --identity-provider {{item.name}} --mapping {{item.attribute_mapping}} {{item.protocol}}
+    federation protocol set \
+    --identity-provider {{ item.name }} \
+    --mapping {{ item.attribute_mapping }} \
+    {{ item.protocol }}
   run_once: True
+  # NOTE(pem): We must allow this task to "fail" because the OpenStack CLI is
+  # returning RC=1 for sucessful executions.
   ignore_errors: yes
   become: true
-  when: identity_providers is defined and identity_providers is not none and (identity_providers | length > 0)  and item.name in configured_identity_providers.split(',')
-  with_items: "{{identity_providers}}"
+  when:
+    - item.name in existing_idps
+  with_items: "{{ keystone_identity_providers }}"

--- a/ansible/roles/keystone/templates/keystone.conf.j2
+++ b/ansible/roles/keystone/templates/keystone.conf.j2
@@ -71,7 +71,7 @@ connection_string = {{ osprofiler_backend_connection_string }}
 allowed_origin = {{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ grafana_server_port }}
 {% endif %}
 
-{% if should_use_oidc or should_use_saml %}
+{% if enable_keystone_federation %}
 [federation]
 {% for dashboard in horizon_trusted_dashboards %}
 trusted_dashboard = {{ dashboard }}
@@ -79,13 +79,11 @@ trusted_dashboard = {{ dashboard }}
 
 sso_callback_template = /etc/keystone/sso_callback_template.html
 
-#SAML configuration
 [mapped]
-remote_id_attribute = {{remote_id_attribute_saml}}
+remote_id_attribute = {{ remote_id_attribute_saml }}
 
-#configuration for OpenID Connect
 [openid]
-remote_id_attribute = {{remote_id_attribute_oidc}}
+remote_id_attribute = {{ remote_id_attribute_oidc }}
 
 [auth]
 methods = external,password,token,mapped,openid

--- a/ansible/roles/keystone/templates/keystone.json.j2
+++ b/ansible/roles/keystone/templates/keystone.json.j2
@@ -34,16 +34,16 @@
             "dest": "/etc/{{ keystone_dir }}/wsgi-keystone.conf",
             "owner": "keystone",
             "perm": "0600"
-        }{% if should_use_oidc %},
+        }{% if enable_keystone_federation_openid %},
         {
             "source": "{{ container_config_directory }}/metadata",
-            "dest": "{{ container_keystone_federation_oidc_metadata_folder }}",
+            "dest": "{{ keystone_federation_oidc_metadata }}",
             "merge": true,
             "preserve_properties": true
         },
         {
             "source": "{{ container_config_directory }}/cert",
-            "dest": "{{ container_keystone_federation_oidc_idp_certificate_folder }}",
+            "dest": "{{ keystone_federation_oidc_certificate }}",
             "merge": true,
             "preserve_properties": true
         }
@@ -57,15 +57,15 @@
         {
             "path": "/var/log/kolla/keystone/keystone.log",
             "owner": "keystone:keystone"
-        },{% if should_use_oidc %}
+        },{% if enable_keystone_federation_openid %}
         {
-            "path": "/etc/apache2/metadata",
+            "path": "{{ keystone_federation_oidc_metadata }}",
             "owner": "www-data:www-data",
             "perm": "0700",
             "recurse": true
         },
         {
-            "path": "/etc/apache2/cert",
+            "path": "{{ keystone_federation_oidc_certificate }}",
             "owner": "www-data:www-data",
             "perm": "0700",
             "recurse": true

--- a/ansible/roles/keystone/templates/keystone.json.j2
+++ b/ansible/roles/keystone/templates/keystone.json.j2
@@ -1,5 +1,6 @@
 {% set keystone_cmd = 'apache2' if kolla_base_distro in ['ubuntu', 'debian'] else 'httpd' %}
 {% set keystone_dir = 'apache2/conf-enabled' if kolla_base_distro in ['ubuntu', 'debian'] else 'httpd/conf.d' %}
+{% set apache_user = 'www-data' if kolla_base_distro in ['ubuntu', 'debian'] else 'apache' %}
 {
     "command": "/usr/sbin/{{ keystone_cmd }}",
     "config_files": [
@@ -60,13 +61,13 @@
         },{% if enable_keystone_federation_openid %}
         {
             "path": "{{ keystone_federation_oidc_metadata }}",
-            "owner": "www-data:www-data",
+            "owner": "{{ apache_user }}:{{ apache_user }}",
             "perm": "0700",
             "recurse": true
         },
         {
             "path": "{{ keystone_federation_oidc_certificate }}",
-            "owner": "www-data:www-data",
+            "owner": "{{ apache_user }}:{{ apache_user }}",
             "perm": "0700",
             "recurse": true
         },{% endif %}

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -41,6 +41,7 @@ LogLevel info
 
 {% if enable_keystone_federation_openid %}
     OIDCClaimPrefix "OIDC-"
+    OIDCClaimDelimiter ";"
     OIDCResponseType "id_token"
     OIDCScope "openid email profile"
     OIDCMetadataDir {{ keystone_federation_oidc_metadata }}

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -39,23 +39,20 @@ LogLevel info
     CustomLog "{{ keystone_log_dir }}/keystone-apache-public-access.log" logformat
     {{ keystone_wsgi_public_vhost_config | indent(4) }}
 
-    {% if should_use_oidc %}
+    {% if enable_keystone_federation_openid %}
     OIDCClaimPrefix "OIDC-"
     OIDCResponseType "id_token"
     OIDCScope "openid email profile"
-    OIDCMetadataDir {{container_keystone_federation_oidc_metadata_folder}}
-    OIDCOAuthVerifyCertFiles {{ certificate_key_ids }}
-
-    OIDCCryptoPassphrase {{oidc_crypto_passphrase}}
-
-    OIDCRedirectURI {{keystone_public_url}}/redirect_uri
+    OIDCMetadataDir {{ keystone_federation_oidc_metadata }}
+    OIDCOAuthVerifyCertFiles {{ certificate_key_ids | join(" ") }}
+    OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
+    OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
 
     <Location ~ "/redirect_uri">
       AuthType auth-openidc
       Require valid-user
       LogLevel debug
     </Location>
-
 
     <LocationMatch /auth/OS-FEDERATION/identity_providers/.*?/protocols/openid/websso>
       AuthType openid-connect

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -49,17 +49,16 @@ LogLevel info
     OIDCOAuthVerifyCertFiles {{ certificate_key_ids | join(" ") }}
 {% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
-{% if keystone_identity_providers | length == 1 %}
-    OIDCRedirectURI {{ keystone_public_url }}/v3/auth/OS-FEDERATION/identity_providers/{{ keystone_identity_providers[0].name }}/protocols/openid/auth
-{% else %}
     OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
+{% if keystone_federation_openid_discovery_url is not none %}
+    OIDCDiscoverURL {{ keystone_federation_openid_discovery_url }}
+{% endif %}
 
     <Location ~ "/redirect_uri">
       Require valid-user
       AuthType openid-connect
       LogLevel debug
     </Location>
-{% endif %}
 
     <LocationMatch /v3/auth/OS-FEDERATION/identity_providers/.*?/protocols/openid/websso>
       Require valid-user

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -67,7 +67,7 @@ LogLevel info
     </LocationMatch>
 
     <LocationMatch /OS-FEDERATION/identity_providers/.*?/protocols/openid/auth>
-      AuthType auth-openidc
+      AuthType openid-connect
       Require valid-user
       LogLevel debug
     </LocationMatch>

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -50,6 +50,7 @@ LogLevel info
 {% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
     OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
+    {# NOTE(jasonanderson): this requires Keystone change Icb77ea82a69a6766d412543d3c2fe75a736bf212 #}
     OIDCDiscoverURL {{ keystone_public_url }}/v3/auth/OS-FEDERATION/websso/openid/discover
 
     <Location ~ "/redirect_uri">

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -39,12 +39,14 @@ LogLevel info
     CustomLog "{{ keystone_log_dir }}/keystone-apache-public-access.log" logformat
     {{ keystone_wsgi_public_vhost_config | indent(4) }}
 
-    {% if enable_keystone_federation_openid %}
+{% if enable_keystone_federation_openid %}
     OIDCClaimPrefix "OIDC-"
     OIDCResponseType "id_token"
     OIDCScope "openid email profile"
     OIDCMetadataDir {{ keystone_federation_oidc_metadata }}
+{% if certificate_key_ids | length > 0 %}
     OIDCOAuthVerifyCertFiles {{ certificate_key_ids | join(" ") }}
+{% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
     OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
 
@@ -65,7 +67,7 @@ LogLevel info
       Require valid-user
       LogLevel debug
     </LocationMatch>
-    {% endif %}
+{% endif %}
 </VirtualHost>
 
 <VirtualHost *:{{ keystone_admin_listen_port }}>

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -49,26 +49,26 @@ LogLevel info
 {% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
 {% if keystone_identity_providers | length == 1 %}
-    OIDCRedirectURI {{ keystone_public_url }}/OS-FEDERATION/identity_providers/{{ keystone_identity_providers[0].name }}/protocols/openid/auth
+    OIDCRedirectURI {{ keystone_public_url }}/v3/auth/OS-FEDERATION/identity_providers/{{ keystone_identity_providers[0].name }}/protocols/openid/auth
 {% else %}
     OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
 
     <Location ~ "/redirect_uri">
-      AuthType openid-connect
       Require valid-user
+      AuthType openid-connect
       LogLevel debug
     </Location>
 {% endif %}
 
-    <LocationMatch /auth/OS-FEDERATION/identity_providers/.*?/protocols/openid/websso>
-      AuthType openid-connect
+    <LocationMatch /v3/auth/OS-FEDERATION/identity_providers/.*?/protocols/openid/websso>
       Require valid-user
+      AuthType openid-connect
       LogLevel debug
     </LocationMatch>
 
-    <LocationMatch /OS-FEDERATION/identity_providers/.*?/protocols/openid/auth>
-      AuthType openid-connect
+    <LocationMatch /v3/auth/OS-FEDERATION/identity_providers/.*?/protocols/openid/auth>
       Require valid-user
+      AuthType openid-connect
       LogLevel debug
     </LocationMatch>
 {% endif %}

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -48,13 +48,17 @@ LogLevel info
     OIDCOAuthVerifyCertFiles {{ certificate_key_ids | join(" ") }}
 {% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
+{% if keystone_identity_providers | length == 1 %}
+    OIDCRedirectURI {{ keystone_public_url }}/OS-FEDERATION/identity_providers/{{ keystone_identity_providers[0].name }}/protocols/openid/auth
+{% else %}
     OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
 
     <Location ~ "/redirect_uri">
-      AuthType auth-openidc
+      AuthType openid-connect
       Require valid-user
       LogLevel debug
     </Location>
+{% endif %}
 
     <LocationMatch /auth/OS-FEDERATION/identity_providers/.*?/protocols/openid/websso>
       AuthType openid-connect

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -50,9 +50,7 @@ LogLevel info
 {% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
     OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
-{% if keystone_federation_openid_discovery_url is not none %}
-    OIDCDiscoverURL {{ keystone_federation_openid_discovery_url }}
-{% endif %}
+    OIDCDiscoverURL {{ keystone_public_url }}/v3/auth/OS-FEDERATION/websso/openid/discover
 
     <Location ~ "/redirect_uri">
       Require valid-user

--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -68,6 +68,7 @@ blazar_keystone_password:
 
 keystone_admin_password:
 keystone_database_password:
+keystone_federation_openid_crypto_password:
 
 grafana_database_password:
 grafana_admin_password:


### PR DESCRIPTION
This builds on changeset I0203a3470d7f8f2a54d5e126d947f540d93b8210, but restructures some of the var setting in order to reduce boilerplate conditionals, and also fixes a few issues I found:

- The WSGI configuration "auth-openidc" is not correct and doesn't work
- Refactor the metadata generation script to pull keys from a .well-known metadata URL if possible
- Update some more bits to adhere to Kolla style, like not using set_facts so much and relying more on computed role vars
- Support multi-value claims, they need to be delimited with semicolons (default is comma for mod_openidc)
- Support for different Apache user on CentOS/RHEL