### PR TITLE
doesn't detect HAProxy version on centos8

### DIFF
--- a/ansible/roles/haproxy/templates/haproxy_run.sh.j2
+++ b/ansible/roles/haproxy/templates/haproxy_run.sh.j2
@@ -1,6 +1,5 @@
 #!/bin/bash -x
-{% set has_haproxy_1_8=kolla_base_distro in ['debian', 'ubuntu'] or (kolla_base_distro == 'centos' and ansible_distribution_major_version is version(8, '>=')) %}
-{% set haproxy_cmd='/usr/sbin/haproxy -W -db' if has_haproxy_1_8 else '/usr/sbin/haproxy-systemd-wrapper' %}
+{% set haproxy_cmd='/usr/sbin/haproxy -W -db' if kolla_base_distro in ['debian', 'ubuntu']  else '/usr/sbin/haproxy-systemd-wrapper' %}
 
 {% if enable_letsencrypt | bool %}
 # Copy LetsEncrypt-managed certificates to HAProxy cert folder


### PR DESCRIPTION
In the case where the host os is centos8, and we manually pull a centos7
container, then this template crashes HAProxy, preventing deploy.

the "-W" flag is not present.