### PR TITLE
Load mod_rewrite module on ubuntu

### DIFF
--- a/ansible/roles/horizon/templates/horizon.conf.j2
+++ b/ansible/roles/horizon/templates/horizon.conf.j2
@@ -2,6 +2,10 @@
 
 Listen {{ api_interface_address | put_address_in_context('url') }}:{{ horizon_listen_port }}
 
+{% if horizon_redirect_root is defined and kolla_base_distro in ['debian', 'ubuntu'] %}
+LoadModule rewrite_module /usr/lib/apache2/modules/mod_rewrite.so
+{% endif %}
+
 ServerSignature Off
 ServerTokens Prod
 TraceEnable off


### PR DESCRIPTION
On ubuntu based builds, mod_rewrite was not loaded by default,
causing horizon to crash on launch.

This is a quick fix, but we should revisit how much horizon configuration lives in each of:
kolla, kolla-containers via additions, kolla-ansible, and chi-in-a-box.