### PR TITLE
Bugfix/keystone become

### DIFF
--- a/ansible/roles/keystone/tasks/config.yml
+++ b/ansible/roles/keystone/tasks/config.yml
@@ -102,7 +102,12 @@
 
 - name: Setting the certificates variable
   set_fact:
-    certificate_key_ids: "{{ certificate_key_ids.results | map(attribute='stdout') | map('trim') | select | map('regex_replace', '(.*)', '\\1#' + keystone_federation_oidc_certificate + '/\\1.pem') | list }}"
+    certificate_key_ids: "{{ certificate_key_ids.results
+    | map(attribute='stdout')
+    | map('trim')
+    | select
+    | map('regex_replace', '^(.*)$', '\\1#' + keystone_federation_oidc_certificate + '/\\1.pem')
+    | list }}"
   when:
     - certificate_key_ids is defined
     - enable_keystone_federation_openid | bool

--- a/ansible/roles/keystone/tasks/config.yml
+++ b/ansible/roles/keystone/tasks/config.yml
@@ -78,7 +78,7 @@
 
 - name: Configure the metadata files for OpenID IdPs
   vars:
-      keystone: "{{ keystone_services.keystone }}"
+    keystone: "{{ keystone_services.keystone }}"
   script: >
     openid_gen_metadata_and_certs.py \
     --output-dir={{ node_config_directory }}/keystone \
@@ -89,6 +89,7 @@
     --jwt-certificate-transformer="{{ item.certificate_transformer|default("") }}" \
     --jwt-key-path="{{ item.key_id|default("") }}" \
     --jwt-key-transformer="{{ item.key_transformer|default("") }}"
+  become: true
   register: certificate_key_ids
   when:
     - enable_keystone_federation_openid | bool


### PR DESCRIPTION
fix 1 is trivial, ensuring become: true is set so metadata files can be created

fix 2 is tricky: when creating a capture group to get the entire string, it is important to specify the line start and end. Specifically, use `^(.*)$` not `(.*)`
If this is not done, the capture group may return an empty string as an extra result, depending on platform and python version.
This is documented at https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#searching-strings-with-regular-expressions

Finally, I would recommend formatting chains of map, select, list, onto multiple lines as shown for readability, and ease of diffing.

