### PR TITLE
Configure HAProxy to allow Let's Encrypt to manage certificate reloads

### DIFF
--- a/ansible/roles/letsencrypt/defaults/main.yml
+++ b/ansible/roles/letsencrypt/defaults/main.yml
@@ -52,4 +52,5 @@ letsencrypt_certbot_default_volumes:
   - "letsencrypt_certs:/etc/letsencrypt"
   - "letsencrypt_acme_webroot:/www/data"
   - "kolla_logs:/var/log/kolla/"
+  - "haproxy_socket:/var/lib/kolla/haproxy"
 letsencrypt_certbot_extra_volumes: "{{ default_extra_volumes }}"

--- a/ansible/roles/loadbalancer/templates/haproxy/haproxy_main.cfg.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy/haproxy_main.cfg.j2
@@ -12,7 +12,11 @@ global
     cpu-map {{ cpu_idx + 1 }} {{ cpu_idx }}
         {% endfor %}
     {% endif %}
+    {% if enable_letsencrypt | bool %}
+    stats socket /var/lib/kolla/haproxy/haproxy.sock group kolla expose-fd listeners mode 660
+    {% else %}
     stats socket /var/lib/kolla/haproxy/haproxy.sock group kolla mode 660
+    {% endif %}
     {% if kolla_enable_tls_external | bool or kolla_enable_tls_internal | bool %}
     ssl-default-bind-ciphers DEFAULT:!MEDIUM:!3DES
     ssl-default-bind-options no-sslv3 no-tlsv10 no-tlsv11

--- a/ansible/roles/loadbalancer/templates/haproxy/haproxy_main.cfg.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy/haproxy_main.cfg.j2
@@ -13,7 +13,7 @@ global
         {% endfor %}
     {% endif %}
     {% if enable_letsencrypt | bool %}
-    stats socket /var/lib/kolla/haproxy/haproxy.sock group kolla expose-fd listeners mode 660
+    stats socket /var/lib/kolla/haproxy/haproxy.sock group kolla expose-fd listeners mode 660 level admin
     {% else %}
     stats socket /var/lib/kolla/haproxy/haproxy.sock group kolla mode 660
     {% endif %}

--- a/ansible/roles/loadbalancer/templates/haproxy/haproxy_run.sh.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy/haproxy_run.sh.j2
@@ -1,17 +1,5 @@
 #!/bin/bash -x
 
-{% if enable_letsencrypt | bool %}
-# Copy LetsEncrypt-managed certificates to HAProxy cert folder
-le_base=/etc/letsencrypt/live
-if [[ -d "$le_base" ]]; then
-    domains=$(find $le_base -mindepth 1 -type d -exec basename {} \;)
-    for domain in $domains; do
-        cat "$le_base/$domain/fullchain.pem" "$le_base/$domain/privkey.pem" \
-            >"/etc/haproxy/certs.d/$domain.pem"
-    done
-fi
-{% endif %}
-
 # We need to run haproxy with one `-f` for each service, because including an
 # entire config directory was not a feature until version 1.7 of HAProxy.
 # So, append "-f $cfg" to the haproxy command for each service file.


### PR DESCRIPTION
Removes cert loading logic from HAProxy, which is instead deferred to Let's Encrypt via a change made in https://github.com/ChameleonCloud/kolla/pull/7. Fixes https://github.com/ChameleonCloud/chi-in-a-box/issues/125
