### PR TITLE
Copy HAProxy reload script at container start

### DIFF
--- a/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
+++ b/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
@@ -2,10 +2,11 @@
 
 # Update HAProxy with new certs via its API
 
+le_base=/etc/letsencrypt/live
 for domain in {{ letsencrypt_domains | join(' ') }}; do
     cert_path="/etc/haproxy/certs.d/$domain.pem"
     # Get the full text of the certificate, deleting any blank lines (OpenSSL doesn't like those)
-    full_cert=$(cat /etc/letsencrypt/live/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
+    full_cert=$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
     # Start a transaction to update the certificate
     echo -e "set ssl cert $cert_path <<\n$full_cert\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
     # Commit the transaction

--- a/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
+++ b/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash 
+
+# Update HAProxy with new certs via its API
+
+for domain in {{ letsencrypt_domains | join(' ') }}; do
+    cert_path="/etc/haproxy/certs.d/$domain.pem"
+    # Get the full text of the certificate, deleting any blank lines (OpenSSL doesn't like those)
+    full_cert=$(cat /etc/letsencrypt/live/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
+    # Start a transaction to update the certificate
+    echo -e "set ssl cert $cert_path <<\n$full_cert\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
+    # Commit the transaction
+    echo "commit ssl cert $cert_path" | socat /var/lib/kolla/haproxy/haproxy.sock -
+done
+

--- a/ansible/roles/letsencrypt/templates/letsencrypt-certbot.json.j2
+++ b/ansible/roles/letsencrypt/templates/letsencrypt-certbot.json.j2
@@ -20,6 +20,12 @@
             "dest": "/usr/sbin/certbot-renew.sh",
             "owner": "root",
             "perm": "0700"
+        },
+        {
+            "source": "{{ container_config_directory }}/haproxy-reload.sh",
+            "dest": /etc/letsencrypt/renewal-hooks/post/haproxy-reload.sh",
+            "owner" "root",
+            "perm": "0700"
         }
     ],
     "permissions": []


### PR DESCRIPTION
The script used to be baked into the Docker image, but it is overwritten
by a configured volume. Instead, the script is copied at start time.
