### PR TITLE
Allow certbot to update certs in HAProxy's config dir

### DIFF
--- a/ansible/roles/letsencrypt/defaults/main.yml
+++ b/ansible/roles/letsencrypt/defaults/main.yml
@@ -53,4 +53,5 @@ letsencrypt_certbot_default_volumes:
   - "letsencrypt_acme_webroot:/www/data"
   - "kolla_logs:/var/log/kolla/"
   - "haproxy_socket:/var/lib/kolla/haproxy"
+  - "/etc/kolla/haproxy:/etc/kolla/haproxy"
 letsencrypt_certbot_extra_volumes: "{{ default_extra_volumes }}"

--- a/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
+++ b/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
@@ -7,7 +7,9 @@ for domain in {{ letsencrypt_domains | join(' ') }}; do
     cert_path="/etc/haproxy/certs.d/haproxy.pem"
     # Get the full text of the certificate, deleting any blank lines (OpenSSL doesn't like those)
     full_cert=$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
-    # Start a transaction to update the certificate
+    # Copy the cert to haproxy's config dir
+    echo $full_cert | tee $cert_path /etc/haproxy/haproxy.pem
+    # Start a transaction to update the certificate in HAProxy's memory
     echo -e "set ssl cert $cert_path <<\n$full_cert\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
     # Commit the transaction
     echo "commit ssl cert $cert_path" | socat /var/lib/kolla/haproxy/haproxy.sock -


### PR DESCRIPTION
The original patch only updated the certs in memory, so restarting
HAProxy would load the old certs.
