### PR TITLE
Have HAProxy load its own certs at startup

### DIFF
--- a/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
+++ b/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
@@ -4,7 +4,7 @@
 
 le_base=/etc/letsencrypt/live
 for domain in {{ letsencrypt_domains | join(' ') }}; do
-    cert_path="/etc/haproxy/certs.d/haproxy.pem"
+    cert_path="/etc/haproxy/certs.d/$domain"
     # Get the full text of the certificate, deleting any blank lines (OpenSSL doesn't like those)
     full_cert=$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
     # Start a transaction to update the certificate

--- a/ansible/roles/loadbalancer/templates/haproxy/haproxy_run.sh.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy/haproxy_run.sh.j2
@@ -1,5 +1,17 @@
 #!/bin/bash -x
 
+{% if enable_letsencrypt | bool %}
+# Copy LetsEncrypt-managed certificates to HAProxy cert folder
+le_base=/etc/letsencrypt/live
+if [[ -d "$le_base" ]]; then
+    domains=$(find $le_base -mindepth 1 -type d -exec basename {} \;)
+    for domain in $domains; do
+        cat "$le_base/$domain/fullchain.pem" "$le_base/$domain/privkey.pem" \
+            >"/etc/haproxy/certs.d/$domain.pem"
+    done
+fi
+{% endif %}
+
 # We need to run haproxy with one `-f` for each service, because including an
 # entire config directory was not a feature until version 1.7 of HAProxy.
 # So, append "-f $cfg" to the haproxy command for each service file.


### PR DESCRIPTION
Part of the Let's Encrypt changes tried to have certbot be fully in charge of managing Let's Encrypt certs. This didn't really work at startup, and the reload script had to be run manually. With this change, HAProxy will load the Let's Encrypt certs by itself on startup, and certbot will only be in charge of reloading it when the certs are renewed live.
