### PR TITLE
Wip/ironic inspector standalone toggle

### DIFF
--- a/ansible/roles/ironic/defaults/main.yml
+++ b/ansible/roles/ironic/defaults/main.yml
@@ -274,6 +274,9 @@ ironic_dev_repos_pull: "{{ kolla_dev_repos_pull }}"
 ironic_dev_mode: "{{ kolla_dev_mode }}"
 ironic_source_version: "{{ kolla_source_version }}"
 
+# If True, (default) allow ironic inspector to run in standalone mode without
+# other openstack services. Can be set to False if always used with Ironic, Neutron, Glance, etc.
+ironic_inspector_standalone: True
 
 ####################
 # Notifications

--- a/ansible/roles/ironic/tasks/config.yml
+++ b/ansible/roles/ironic/tasks/config.yml
@@ -144,6 +144,7 @@
     - service.enabled | bool
     - not enable_ironic_pxe_uefi | bool
     - not enable_ironic_ipxe | bool
+    - ironic_inspector_standalone | bool
   notify:
     - Restart ironic-pxe container
 
@@ -184,6 +185,7 @@
     - service.enabled | bool
     - not enable_ironic_pxe_uefi | bool
     - not enable_ironic_ipxe | bool
+    - ironic_inspector_standalone | bool
   notify:
     - Restart ironic-pxe container
 
@@ -203,6 +205,7 @@
     - groups['ironic-inspector'] | length > 0
     - inventory_hostname in groups[service.group]
     - service.enabled | bool
+    - ironic_inspector_standalone | bool
   notify:
     - Restart ironic-ipxe container
 
@@ -223,6 +226,7 @@
     - groups['ironic-inspector'] | length > 0
     - inventory_hostname in groups[service.group]
     - service.enabled | bool
+    - ironic_inspector_standalone | bool
   notify:
     - Restart ironic-ipxe container
 

--- a/ansible/roles/ironic/templates/ironic-ipxe.json.j2
+++ b/ansible/roles/ironic/templates/ironic-ipxe.json.j2
@@ -3,7 +3,7 @@
 {
     "command": "{{ apache_cmd }} -DFOREGROUND",
     "config_files": [
-{% if groups['ironic-inspector'] | length > 0 %}
+{% if groups['ironic-inspector'] | length > 0 and ironic_inspector_standalone | bool %}
         {
             "source": "{{ container_config_directory }}/ironic-agent.kernel",
             "dest": "/httpboot/ironic-agent.kernel",

--- a/ansible/roles/ironic/templates/ironic-pxe.json.j2
+++ b/ansible/roles/ironic/templates/ironic-pxe.json.j2
@@ -4,7 +4,7 @@
 {
     "command": "/usr/sbin/in.tftpd --verbose --foreground --user nobody --address 0.0.0.0:69 --map-file /map-file /tftpboot",
     "config_files": [
-{% if not enable_ironic_ipxe | bool and groups['ironic-inspector'] | length > 0 %}
+{% if not enable_ironic_ipxe | bool and groups['ironic-inspector'] | length > 0 and ironic_inspector_standalone | bool %}
 {% if not enable_ironic_pxe_uefi | bool %}
         {
             "source": "{{ container_config_directory }}/ironic-agent.kernel",


### PR DESCRIPTION
If ironic-inspector is used "standalone", it needs to run its own
dnsmasq instance as dhcp+pxe server, and serve the ironic-agent kernel
and initramfs itself.

If not used standalone, e.g. always used with managed boot, and ironic,
glance, and keystone, then we don't actually ever use these files, and
the weighty config can be skipped entirely.