### PR TITLE
support dev mode for nova plugins

### DIFF
--- a/ansible/roles/nova/defaults/main.yml
+++ b/ansible/roles/nova/defaults/main.yml
@@ -160,7 +160,11 @@ nova_api_bootstrap_default_volumes:
   - "kolla_logs:/var/log/kolla/"
   - "{{ kolla_dev_repos_directory ~ '/nova/nova:/var/lib/kolla/venv/lib/python' ~ distro_python_version ~ '/site-packages/nova' if nova_dev_mode | bool else '' }}"
 
-nova_extra_volumes: "{{ default_extra_volumes }}"
+
+nova_plugin_volumes_raw: "{% for plugin in nova_dev_plugins %}{% for pkg in plugin.packages %}{{ kolla_dev_repos_directory ~ '/nova-plugins/' ~ plugin.name ~ '/' ~ pkg ~ ':/var/lib/kolla/venv/lib/python' ~ distro_python_version ~ '/site-packages/' ~ pkg if nova_dev_mode | bool else '' }},{% endfor %}{% endfor %}"
+nova_plugin_volumes: "{{ nova_plugin_volumes_raw.split(',') }}"
+
+nova_extra_volumes: "{{ default_extra_volumes + nova_plugin_volumes }}"
 nova_api_extra_volumes: "{{ nova_extra_volumes }}"
 nova_scheduler_extra_volumes: "{{ nova_extra_volumes }}"
 nova_super_conductor_extra_volumes: "{{ nova_extra_volumes }}"
@@ -237,6 +241,7 @@ nova_git_repository: "{{ kolla_dev_repos_git }}/{{ project_name }}"
 nova_dev_repos_pull: "{{ kolla_dev_repos_pull }}"
 nova_dev_mode: "{{ kolla_dev_mode }}"
 nova_source_version: "{{ kolla_source_version }}"
+nova_dev_plugins: []
 
 ####################
 # TLS

--- a/ansible/roles/nova/tasks/clone.yml
+++ b/ansible/roles/nova/tasks/clone.yml
@@ -6,3 +6,30 @@
     dest: "{{ kolla_dev_repos_directory }}/{{ project_name }}"
     update: "{{ nova_dev_repos_pull }}"
     version: "{{ nova_source_version }}"
+
+- name: Cloning nova plugin source repositories for development
+  become: true
+  git:
+    repo: "{{ item.git_repository | default(kolla_dev_repos_directory ~ '/' ~ item.name) }}"
+    dest: "{{ kolla_dev_repos_directory }}/{{ project_name }}-plugins/{{ item.name }}"
+    update: "{{ item.repos_pull | default(nova_dev_repos_pull) }}"
+    version: "{{ item.source_version | default(nova_source_version) }}"
+  loop: "{{ nova_dev_plugins }}"
+
+- name: change ownership on nova checkout
+  become: true
+  file:
+    path: "{{ kolla_dev_repos_directory }}/{{ project_name }}"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    state: directory
+    recurse: yes
+
+- name: change ownership on plugins checkout
+  become: true
+  file:
+    path: "{{ kolla_dev_repos_directory }}/{{ project_name }}-plugins/"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    state: directory
+    recurse: yes


### PR DESCRIPTION
using the same approach as for neutron, enable loading plugins while in dev_mode for nova

to enable, specify a configuration like the following:

```
kolla_dev_repos_git: https://github.com/chameleoncloud
nova_dev_mode: yes
nova_source_version: chameleoncloud/xena

nova_dev_plugins:
  - name: blazar-nova
    git_repository: https://github.com/ChameleonCloud/blazar-nova
    source_version: "chameleoncloud/xena"
    packages:
      - blazarnova
```