### PR TITLE
fix haproxy cert renewal

### DIFF
--- a/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
+++ b/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
@@ -1,15 +1,30 @@
 #!/bin/bash 
 
 # Update HAProxy with new certs via its API
+logfile_path="/var/log/kolla/letsencrypt/letsencrypt.log"
+print_log () {
+  datetime="$(date --rfc-3339='seconds')"
+  echo "${datetime} haproxy_renew.sh ${1}" >> "${logfile_path}"
+}
 
+haproxy_socket="/var/lib/kolla/haproxy/haproxy.sock"
 le_base=/etc/letsencrypt/live
 for domain in {{ letsencrypt_domains | join(' ') }}; do
     cert_path="/etc/haproxy/certs.d/$domain.pem"
+
     # Get the full text of the certificate, deleting any blank lines (OpenSSL doesn't like those)
     full_cert=$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
+
     # Start a transaction to update the certificate
-    echo -e "set ssl cert $cert_path <<\n$full_cert\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
+    set_ssl_result=$(echo -e "set ssl cert $cert_path <<\n$full_cert\n" | socat ${haproxy_socket} -)
+    print_log "${set_ssl_result}"
+
     # Commit the transaction
-    echo "commit ssl cert $cert_path" | socat /var/lib/kolla/haproxy/haproxy.sock -
+    commit_ssl_result=$(echo "commit ssl cert $cert_path" | socat ${haproxy_socket} -)
+    print_log "${commit_ssl_result}"
+
+    # show properties of newly loaded cert
+    show_cert_result="$(echo -e show ssl cert ${cert_path} | socat ${haproxy_socket} -)"
+    print_log "new cert: ${show_cert_result}"
 done
 

--- a/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
+++ b/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
@@ -1,6 +1,8 @@
-#!/bin/bash 
+#!/bin/bash
 
 # Update HAProxy with new certs via its API
+set -e -u -o pipefail
+
 logfile_path="/var/log/kolla/letsencrypt/letsencrypt.log"
 print_log () {
   datetime="$(date --rfc-3339='seconds')"
@@ -27,4 +29,3 @@ for domain in {{ letsencrypt_domains | join(' ') }}; do
     show_cert_result="$(echo -e show ssl cert ${cert_path} | socat ${haproxy_socket} -)"
     print_log "new cert: ${show_cert_result}"
 done
-

--- a/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
+++ b/ansible/roles/letsencrypt/templates/haproxy-reload.sh.j2
@@ -4,7 +4,7 @@
 
 le_base=/etc/letsencrypt/live
 for domain in {{ letsencrypt_domains | join(' ') }}; do
-    cert_path="/etc/haproxy/certs.d/$domain"
+    cert_path="/etc/haproxy/certs.d/$domain.pem"
     # Get the full text of the certificate, deleting any blank lines (OpenSSL doesn't like those)
     full_cert=$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
     # Start a transaction to update the certificate

--- a/ansible/roles/letsencrypt/templates/letsencrypt-certbot.json.j2
+++ b/ansible/roles/letsencrypt/templates/letsencrypt-certbot.json.j2
@@ -23,7 +23,7 @@
         },
         {
             "source": "{{ container_config_directory }}/haproxy-reload.sh",
-            "dest": "/etc/letsencrypt/renewal-hooks/post/haproxy-reload.sh",
+            "dest": "/etc/letsencrypt/renewal-hooks/deploy/haproxy-reload.sh",
             "owner": "root",
             "perm": "0700"
         }


### PR DESCRIPTION
1. execute script only on successful renewal, not on every renewal check.
2. set correct path for cert file to match filename in haproxy container, [specified here](https://github.com/ChameleonCloud/kolla-ansible/blob/ccc1071943abf3c3d925a8083f7d2b68c6b8daad/ansible/roles/loadbalancer/templates/haproxy/haproxy_run.sh.j2#L10).
3. print results of admin socket operations to logfile.

Example logfile output:
```
2024-04-12 12:12:14-05:00 haproxy_renew.sh Transaction created for certificate /etc/haproxy/certs.d/chi.uc.chameleoncloud.org.pem!
2024-04-12 12:12:14-05:00 haproxy_renew.sh Committing /etc/haproxy/certs.d/chi.uc.chameleoncloud.org.pem..................
Success!
2024-04-12 12:12:14-05:00 haproxy_renew.sh new cert: Filename: /etc/haproxy/certs.d/chi.uc.chameleoncloud.org.pem
Status: Used
Serial: 04BB400AC7DE27651320F028F4F44992CF02
notBefore: Apr  6 07:32:10 2024 GMT
notAfter: Jul  5 07:32:09 2024 GMT
Subject Alternative Name: DNS:chi.uc.chameleoncloud.org
Algorithm: RSA4096
SHA1 FingerPrint: AA65CC746F103A57BE1749283CAA71495B95D7FD
Subject: /CN=chi.uc.chameleoncloud.org
Issuer: /C=US/O=Let's Encrypt/CN=R3
Chain Subject: /C=US/O=Let's Encrypt/CN=R3
Chain Issuer: /C=US/O=Internet Security Research Group/CN=ISRG Root X1
```