### PR TITLE
Train/backport kvm fixes

### DIFF
--- a/ansible/roles/keystone/tasks/config.yml
+++ b/ansible/roles/keystone/tasks/config.yml
@@ -53,6 +53,7 @@
   file:
     state: absent
     path: "{{ node_config_directory }}/keystone/{{ item }}"
+  become: true
   with_items:
     - metadata
     - cert
@@ -67,6 +68,8 @@
     dest: "{{ node_config_directory }}/keystone/{{ item }}"
     state: "directory"
     mode: "0770"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
   become: true
   with_items:
     - metadata

--- a/ansible/roles/keystone/tasks/register_identity_providers.yml
+++ b/ansible/roles/keystone/tasks/register_identity_providers.yml
@@ -23,6 +23,7 @@
       --os-username={{ openstack_auth.username }} \
       --os-project-name={{ openstack_auth.project_name }} \
       --os-identity-api-version={{ identity_api_version }} \
+      --os-interface={{ openstack_interface }} \
     mapping list -c ID --format value
   run_once: True
   become: True
@@ -39,6 +40,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     mapping delete {{ item }}
   run_once: True
   become: true
@@ -55,6 +57,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     mapping create \
     --rules "{{ container_config_directory }}/mappings/{{ item.file | basename }}" \
     {{ item.name }}
@@ -71,6 +74,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     mapping set \
     --rules "{{ container_config_directory }}/mappings/{{ item.file | basename }}" \
     {{ item.name }}
@@ -87,6 +91,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     identity provider list -c ID --format value
   run_once: True
   become: true
@@ -103,6 +108,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     identity provider delete {{ item }}
   run_once: True
   become: true
@@ -116,6 +122,8 @@
     module_name: os_keystone_domain
     module_args:
       auth: "{{ openstack_auth }}"
+      endpoint_type: "{{ openstack_interface }}"
+      cacert: "{{ openstack_cacert }}"
       name: "{{ item.domain_name }}"
       description: "Identity domain for {{ item.name }}"
   run_once: True
@@ -132,6 +140,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     identity provider create \
     --description "{{ item.public_name }}" \
     --remote-id "{{ item.identifier }}" \
@@ -150,6 +159,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     identity provider set \
     --description "{{ item.public_name }}" \
     --remote-id "{{ item.identifier }}" \
@@ -168,6 +178,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     federation protocol create \
     --mapping {{ item.attribute_mapping }} \
     --identity-provider {{ item.name }} \
@@ -186,6 +197,7 @@
     --os-username={{ openstack_auth.username }} \
     --os-project-name={{ openstack_auth.project_name }} \
     --os-identity-api-version={{ identity_api_version }} \
+    --os-interface={{ openstack_interface }} \
     federation protocol set \
     --identity-provider {{ item.name }} \
     --mapping {{ item.attribute_mapping }} \

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -54,6 +54,7 @@ LogLevel info
     {# NOTE(jasonanderson): this requires Keystone change Icb77ea82a69a6766d412543d3c2fe75a736bf212 -#}
     OIDCDiscoverURL {{ keystone_public_url }}/v3/auth/OS-FEDERATION/websso/openid/discover
 {% if keystone_federation_oidc_allowed_redirects | length > 0 %}
+    OIDCXForwardedHeaders X-Forwarded-Proto
     OIDCRedirectURLsAllowed {{ keystone_federation_oidc_allowed_redirects | join(" ") }}
 {% endif %}
 


### PR DESCRIPTION
Small list of fixes needed to get keystone federation working happily.

1. ensure that `config/keystone/metadata` is owned by config_owner_user:config_owner_group, instead of always root, to prevent permissions issues when running kolla-ansible not as root
2. ensure that keystone ansible roles and docker exec tasks use the correct api interface, auth url, and certs, otherwise deployment will fail when self-signed certs are in use
3. handle non-backwards-compatible change in mod_auth_openidc v2.4.11: https://github.com/OpenIDC/mod_auth_openidc/releases/tag/v2.4.11 
"make interpretation of X-Forwarded-* headers configurable, defaulting to none so mod_auth_openidc running behind a reverse proxy that sets X-Forwarded-* headers needs explicit configuration of OIDCXForwardedHeaders"