### PR TITLE
Fix keystone configuration for haproxy.

### DIFF
--- a/ansible/roles/keystone/defaults/main.yml
+++ b/ansible/roles/keystone/defaults/main.yml
@@ -16,6 +16,8 @@ keystone_services:
         external: false
         port: "{{ keystone_public_port }}"
         listen_port: "{{ keystone_public_listen_port }}"
+        backend_http_extra:
+          - balance "{{ 'source' if enable_keystone_federation | bool else 'roundrobin' }}"
       keystone_external:
         enabled: "{{ enable_keystone }}"
         mode: "http"
@@ -28,6 +30,8 @@ keystone_services:
         external: false
         port: "{{ keystone_admin_port }}"
         listen_port: "{{ keystone_admin_listen_port }}"
+        backend_http_extra:
+          - balance "{{ 'source' if enable_keystone_federation | bool else 'roundrobin' }}"
   keystone-ssh:
     container_name: "keystone_ssh"
     group: "keystone"

--- a/releasenotes/notes/bug-2058656-ad68bb260327a267.yaml
+++ b/releasenotes/notes/bug-2058656-ad68bb260327a267.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes keystone service configuration for haproxy when using federation.
+    `LP#2058656 <https://bugs.launchpad.net/kolla-ansible/+bug/2058656>`__


### PR DESCRIPTION
* Use proper balancing mode when federation is enabled.

Closes-Bug: #2058656
Change-Id: Ia81a6efc38ec2bdc1355d058c03568cf740fdac5