### PR TITLE
horizon: Support custom themes

### DIFF
--- a/ansible/roles/horizon/defaults/main.yml
+++ b/ansible/roles/horizon/defaults/main.yml
@@ -73,6 +73,8 @@ horizon_services:
 horizon_keystone_domain_choices:
   Default: default
 
+horizon_custom_themes: []
+
 ####################
 # Database
 ####################

--- a/ansible/roles/horizon/tasks/config.yml
+++ b/ansible/roles/horizon/tasks/config.yml
@@ -215,6 +215,22 @@
   notify:
     - Restart horizon container
 
+- name: Copying over custom themes
+  become: true
+  vars:
+    horizon: "{{ horizon_services['horizon'] }}"
+  copy:
+    src: "{{ node_custom_config }}/horizon/themes/{{ item.name }}"
+    dest: "{{ node_config_directory }}/horizon/themes/"
+    mode: 0660
+  when:
+    - horizon.enabled | bool
+    - inventory_hostname in groups[horizon.group]
+    - horizon_custom_themes | length > 0
+  with_items: "{{ horizon_custom_themes }}"
+  notify:
+    - Restart horizon container
+
 - include_tasks: copy-certs.yml
   when:
     - kolla_copy_ca_into_containers | bool or horizon_enable_tls_backend | bool

--- a/ansible/roles/horizon/templates/horizon.json.j2
+++ b/ansible/roles/horizon/templates/horizon.json.j2
@@ -55,6 +55,12 @@
             "dest": "/etc/horizon/certs/horizon-key.pem",
             "owner": "horizon",
             "perm": "0600"
+        }{% endif %}{% if horizon_custom_themes | length > 0 %},
+        {
+            "source": "{{ container_config_directory}}/themes",
+            "dest": "/etc/openstack-dashboard/themes",
+            "owner": "horizon",
+            "perm": "0600"
         }{% endif %}
     ]
 }

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -527,6 +527,15 @@ POLICY_FILES_PATH = '/etc/openstack-dashboard'
 #    ('default', 'Default', 'themes/default'),
 #    ('material', 'Material', 'themes/material'),
 #]
+{% if horizon_custom_themes | length > 0 %}
+AVAILABLE_THEMES = [
+     ('default', 'Default', 'themes/default'),
+     ('material', 'Material', 'themes/material'),
+{% for theme in horizon_custom_themes %}
+     ('{{ theme.name|e }}', '{{ theme.label|e }}', '/etc/openstack-dashboard/themes/{{ theme.name|e }}'),
+{% endfor %}
+]
+{% endif %}
 
 LOGGING = {
     'version': 1,

--- a/doc/source/reference/shared-services/horizon-guide.rst
+++ b/doc/source/reference/shared-services/horizon-guide.rst
@@ -27,3 +27,27 @@ a file named custom_local_settings should be created under the directory
                 ('material', 'Material', 'themes/material'),
    ]
 
+As a result material theme will be the only one available, and used by default.
+Other way of setting default theme is shown in the next section.
+
+Adding custom themes
+--------------------
+
+It is possible to add custom themes to be available for Horizon
+by using ``horizon_custom_themes`` configuration variable in ``globals.yml``.
+This entry updates AVAILABLE_THEMES adding the new theme at the list end.
+
+.. code-block:: yaml
+
+   horizon_custom_themes:
+     - name: my_custom_theme
+       label: CustomTheme
+
+Theme files have to be copied into:
+``{{ node_custom_config }}/horizon/themes/my_custom_theme``.
+The new theme can be set as default in custom_local_settings:
+
+.. code-block:: python
+
+   DEFAULT_THEME = 'my_custom_theme'
+

--- a/releasenotes/notes/horizon-custom-themes-41b3f349dc118e88.yaml
+++ b/releasenotes/notes/horizon-custom-themes-41b3f349dc118e88.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    ``horizon`` deployment now supports custom themes.


### PR DESCRIPTION
Custom themes support for horizon deployment.
 - horizon role task added for copying theme files
 - added theme copying into the container in templates
 - docs and reno updated

Change-Id: If9982c8e18be31772cb031ef72b7eebd4d768be5

Depends-On: https://review.opendev.org/c/openstack/kayobe/+/824565
Depends-On: https://review.opendev.org/c/openstack/kolla/+/826672