### PR TITLE
support editable installs without yq

### DIFF
--- a/tools/kolla-ansible
+++ b/tools/kolla-ansible
@@ -99,10 +99,10 @@ function find_base_dir {
             if test -f ${VIRTUAL_ENV}/lib/${python_dir}/site-packages/kolla-ansible.egg-link; then
                 # Editable install.
                 BASEDIR="$(head -n1 ${VIRTUAL_ENV}/lib/${python_dir}/*-packages/kolla-ansible.egg-link)"
-            elif test -f ${VIRTUAL_ENV}/lib/${python_dir}/site-packages/kolla_ansible*.dist-info/direct_url.json; then
-                # Editable install in local path
-                direct_url="$(yq eval '.url' ${VIRTUAL_ENV}/lib/${python_dir}/site-packages/kolla_ansible*.dist-info/direct_url.json)"
-                BASEDIR="${direct_url#file:\/\/}"
+            elif test -f ${VIRTUAL_ENV}/lib/${python_dir}/*-packages/kolla_ansible*.dist-info/direct_url.json; then
+                # Modern editable install uses dist_info, not egg-link
+                local json_file="$(echo ${VIRTUAL_ENV}/lib/${python_dir}/*-packages/kolla_ansible*.dist-info/direct_url.json)"
+                BASEDIR="$(python -c "import json; print(json.load(open('${json_file}'))['url'].replace('file://', ''))")"
             else
                 BASEDIR="${VIRTUAL_ENV}/share/kolla-ansible"
             fi


### PR DESCRIPTION
instead of depending on yq to parse direct_url.json, use python json support, since we have it anyway.

This is a proper fix for supporting kolla-ansible when installed via `pip install -e /path/to/kolla-ansible`

Change-Id: I9860fd0c36bd0205420dd77f2ec3cdcf53af20bf