### PR TITLE
Fix/keystone memcached

### DIFF
--- a/ansible/roles/keystone/defaults/main.yml
+++ b/ansible/roles/keystone/defaults/main.yml
@@ -208,6 +208,9 @@ keystone_host_federation_oidc_idp_certificate_folder: "{{ node_config_directory 
 keystone_host_federation_oidc_attribute_mappings_folder: "{{ node_config_directory }}/keystone/federation/oidc/attribute_maps"
 keystone_federation_oidc_jwks_uri: ""
 
+# OIDC caching
+keystone_oidc_enable_memcached: "{{ enable_memcached }}"
+
 # These variables are used to define multiple trusted Horizon dashboards.
 # keystone_trusted_dashboards: ['<https://dashboardServerOne/auth/websso/>', '<https://dashboardServerTwo/auth/websso/>', '<https://dashboardServerN/auth/websso/>']
 keystone_trusted_dashboards: "{{ ['%s://%s/auth/websso/' % (public_protocol, kolla_external_fqdn), '%s/auth/websso/' % (horizon_public_endpoint)] if enable_horizon | bool else [] }}"
@@ -218,6 +221,7 @@ keystone_federation_oidc_response_type: "id_token"
 keystone_federation_oidc_scopes: "openid email profile"
 keystone_federation_oidc_allowed_redirects: []
 
+
 ####################
 # WSGI
 ####################
@@ -227,3 +231,4 @@ keystone_wsgi_public_vhost_config: |
 keystone_wsgi_admin_vhost_config: |
   {{'#'}} Custom vhost configuration can be added here via
   {{'#'}} the `keystone_wsgi_admin_vhost_config` variable.
+

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -83,6 +83,10 @@ LogLevel info
 {% if keystone_federation_oidc_allowed_redirects | length > 0 %}
     OIDCRedirectURLsAllowed {{ keystone_federation_oidc_allowed_redirects | join(" ") }}
 {% endif %}
+{% if enable_memcached | bool and keystone_oidc_enable_memcached | bool %}
+    OIDCCacheType memcache
+    OIDCMemCacheServers "{% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+{% endif %}
 
     <Location /redirect_uri>
       Require valid-user

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -85,7 +85,7 @@ LogLevel info
 {% endif %}
 {% if enable_memcached | bool and keystone_oidc_enable_memcached | bool %}
     OIDCCacheType memcache
-    OIDCMemCacheServers "{% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+    OIDCMemCacheServers "{% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %} {% endif %}{% endfor %}"
 {% endif %}
 
     <Location /redirect_uri>

--- a/releasenotes/notes/oidc-memcache-backend-198e27c5168a3d4e.yaml
+++ b/releasenotes/notes/oidc-memcache-backend-198e27c5168a3d4e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Keystone OIDC integration now uses memcached for the caching backend if
+    ``enable_memcached`` is ``True``. This can be disabled by setting
+    ``keystone_oidc_enable_memcached`` to ``False``.


### PR DESCRIPTION
backport fixes to use memcached with oidc backend

When this isn't enabled, we see a large amount of login events in our keycloak server.