### PR TITLE
feat(k3s): update nvidia device plugin version and config

### DIFF
--- a/ansible/roles/k3s/defaults/main.yml
+++ b/ansible/roles/k3s/defaults/main.yml
@@ -65,7 +65,7 @@ calico_version: v3.30.2
 ########################
 # Nvidia Runtime config
 ########################
-k3s_nvidia_device_plugin_version: "v0.14.1"
+k3s_nvidia_device_plugin_version: "v0.19.0"
 k3s_nvidia_device_plugin_image_full: "nvcr.io/nvidia/k8s-device-plugin:{{ k3s_nvidia_device_plugin_version }}"
 
 ###############################

--- a/ansible/roles/k3s/templates/nvidia-device-plugin.yaml.j2
+++ b/ansible/roles/k3s/templates/nvidia-device-plugin.yaml.j2
@@ -43,12 +43,18 @@ spec:
         - image: "{{ k3s_nvidia_device_plugin_image_full }}"
           name: nvidia-device-plugin-ctr
           env:
+            - name: DEVICE_LIST_STRATEGY
+              value: envvar
+            - name: DEVICE_DISCOVERY_STRATEGY
+              value: tegra
+            - name: DEVICE_ID_STRATEGY
+              value: index
             - name: FAIL_ON_INIT_ERROR
               value: "false"
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
             - name: NVIDIA_DRIVER_CAPABILITIES
-              value: all
+              value: compute,utility
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -56,7 +62,19 @@ spec:
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
+            - name: cdi
+              mountPath: /var/run/cdi
+            - name: nv-tegra-release
+              mountPath: /etc/nv_tegra_release
+              readOnly: true
       volumes:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
+        - name: cdi
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        - name: nv-tegra-release
+          hostPath:
+            path: /etc/nv_tegra_release


### PR DESCRIPTION
Configure the plugin for Tegra/Jetson CDI-based GPU discovery:
- DEVICE_LIST_STRATEGY=envvar (injects NVIDIA_VISIBLE_DEVICES)
- DEVICE_DISCOVERY_STRATEGY=tegra
- DEVICE_ID_STRATEGY=index (avoids tegra UUID issue)

Add newly required mounts for tegra detection:
- /var/run/cdi
- /etc/nv_tegra_release

This brings us up to date with a compatible config for v0.19.0