### PR TITLE
neutron-wireguard: fix volume permissions

### DIFF
--- a/ansible/roles/neutron/templates/neutron-wireguard-agent.json.j2
+++ b/ansible/roles/neutron/templates/neutron-wireguard-agent.json.j2
@@ -34,6 +34,11 @@
             "path": "/var/log/kolla/neutron",
             "owner": "neutron:neutron",
             "recurse": true
+        },
+        {
+            "path": "/etc/neutron/plugins/wireguard",
+            "owner": "neutron:neutron",
+            "recurse": true
         }
     ]
 }


### PR DESCRIPTION
volumes are created with root:root ownership by default.
fix permissions so wireguard-agent can access its volume.