### PR TITLE
fix horizon dev_mode, 2024.1 hack

### DIFF
--- a/ansible/roles/horizon/defaults/main.yml
+++ b/ansible/roles/horizon/defaults/main.yml
@@ -155,6 +155,9 @@ horizon_dev_repos_pull: "{{ kolla_dev_repos_pull }}"
 horizon_dev_mode: "{{ kolla_dev_mode }}"
 horizon_source_version: "{{ kolla_source_version }}"
 
+# 2024.1 only workaround
+horizon_local_settings_d: "{{ ('/var/lib/kolla/venv/lib/python' ~ distro_python_version ~ '/site-packages/openstack_dashboard/local/local_settings.d') if horizon_dev_mode | bool else '/etc/openstack-dashboard/local_settings.d' }}"
+
 horizon_blazar_dev_mode: "{{ kolla_dev_mode }}"
 horizon_blazar_source_version: "{{ kolla_source_version }}"
 

--- a/ansible/roles/horizon/templates/horizon.json.j2
+++ b/ansible/roles/horizon/templates/horizon.json.j2
@@ -20,13 +20,13 @@
 {% endfor %}
         {
             "source": "{{ container_config_directory }}/_9998-kolla-settings.py",
-            "dest": "/etc/openstack-dashboard/local_settings.d/_9998-kolla-settings.py",
+            "dest": "{{ horizon_local_settings_d }}/_9998-kolla-settings.py",
             "owner": "horizon",
             "perm": "0600"
         },
         {
             "source": "{{ container_config_directory }}/_9999-custom-settings.py",
-            "dest": "/etc/openstack-dashboard/local_settings.d/_9999-custom-settings.py",
+            "dest": "{{ horizon_local_settings_d }}/_9999-custom-settings.py",
             "owner": "horizon",
             "perm": "0600"
         },


### PR DESCRIPTION
2024.1 switched to reading /etc/horizon/local settings.d, but the dev_mode mounts shadow this directory.

2025.1 refactors dev mode entirely, so just apply this workaround during the 2024.1 transition.